### PR TITLE
Fix Readme for Ubuntu

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Check [Wiki Page](../../wiki) for more information about each algorithm, as visu
 ## Using the application
 - Clone GitHub repository
 - Install requirements: `pip install -r requirements.txt`
+   - if using Ubuntu, install dependencies first: `sudo apt-get install python-dev libsdl-image1.2-dev libsdl-mixer1.2-dev libsdl-ttf2.0-dev libsdl1.2-dev libsmpeg-dev python-numpy subversion libportmidi-dev ffmpeg libswscale-dev libavformat-dev libavcodec-dev libfreetype6-dev`
 - Run: `python main.py`
 
 ## How to contribute: 


### PR DESCRIPTION
I got the following error message saying I needed some extra packages and it's fixed after installing them. Not sure if it's only a ubuntu/linux thing

```
Collecting pygame==1.9.6
  Using cached pygame-1.9.6.tar.gz (3.2 MB)
    ERROR: Command errored out with exit status 1:
     command: /usr/bin/python3 -c 'import sys, setuptools, tokenize; sys.argv[0] = '"'"'/tmp/pip-install-b_mz1dh_/pygame/setup.py'"'"'; __file__='"'"'/tmp/pip-install-b_mz1dh_/pygame/setup.py'"'"';f=getattr(tokenize, '"'"'open'"'"', open)(__file__);code=f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' egg_info --egg-base /tmp/pip-install-b_mz1dh_/pygame/pip-egg-info
         cwd: /tmp/pip-install-b_mz1dh_/pygame/
    Complete output (29 lines):
    
    
    WARNING, No "Setup" File Exists, Running "buildconfig/config.py"
    Using UNIX configuration...
    
    /bin/sh: 1: sdl-config: not found
    /bin/sh: 1: sdl-config: not found
    /bin/sh: 1: sdl-config: not found
    Package freetype2 was not found in the pkg-config search path.
    Perhaps you should add the directory containing `freetype2.pc'
    to the PKG_CONFIG_PATH environment variable
    No package 'freetype2' found
    Package freetype2 was not found in the pkg-config search path.
    Perhaps you should add the directory containing `freetype2.pc'
    to the PKG_CONFIG_PATH environment variable
    No package 'freetype2' found
    Package freetype2 was not found in the pkg-config search path.
    Perhaps you should add the directory containing `freetype2.pc'
    to the PKG_CONFIG_PATH environment variable
    No package 'freetype2' found
    /bin/sh: 1: freetype-config: not found
    /bin/sh: 1: freetype-config: not found
    /bin/sh: 1: freetype-config: not found
    
    Hunting dependencies...
    WARNING: "sdl-config" failed!
    WARNING: "pkg-config freetype2" failed!
    WARNING: "freetype-config" failed!
    Unable to run "sdl-config". Please make sure a development version of SDL is installed.
    ----------------------------------------
ERROR: Command errored out with exit status 1: python setup.py egg_info Check the logs for full command output.
```