### PR TITLE
Changed the order of the drawBottomMenu function

### DIFF
--- a/display.py
+++ b/display.py
@@ -196,7 +196,7 @@ class DropdownBox():
 sizeBox  = TextBox("Size", grey, (30, 440, 50, 50), '100')
 delayBox = SliderBox("Delay", grey, (105, 440, 112, 50))
 algorithmBox = DropdownBox("Algorithm", (242, 440, 140, 50), baseFont)
-startButton  = ButtonBox('images/playButton.png', 'images/stopButton.png', (390, 435, 50, 50))
+startButton  = ButtonBox('images/playButton.png', 'images/stopButton.png', (390, 440, 50, 50))
 
 # Global Variables
 numBars = 0
@@ -223,8 +223,8 @@ def drawBottomMenu():
     """Draw the menu below the bars"""
     sizeBox.draw()
     delayBox.draw()
-    algorithmBox.draw()
     startButton.draw()
+    algorithmBox.draw()
 
 def draw_rect_alpha(surface, color, rect):
     shape_surf = pygame.Surface(pygame.Rect(rect).size, pygame.SRCALPHA)


### PR DESCRIPTION
Hey there!

Made a small visual change in the display.py file. 
Now the start button image will render before the algorithm box rectangle. 
Also aligned the height of the button with the rest of the boxes.

For reference, this is before the change:
![image](https://user-images.githubusercontent.com/61670871/127230957-881be712-2cc5-4d3c-883e-09ecd90afb2a.png)

Now after the change:
![image](https://user-images.githubusercontent.com/61670871/127231302-75b30b9d-6564-4ffd-9f55-c4d1296c0b38.png)
