### PR TITLE
Fixing syntax error in bubleSort.py

### DIFF
--- a/algorithms/bubbleSort.py
+++ b/algorithms/bubbleSort.py
@@ -7,5 +7,5 @@ def bubbleSort(array, *args):
             if array[j] > array[j + 1]:
                 array[j], array[j + 1] = array[j + 1], array[j]
                 swapped = True
-        if !swapped:
+        if not swapped:
             break


### PR DESCRIPTION
There's a syntax error in bubleSort.py that gives an error when running `python3 main.py`

Error traceback- 
```
[subhashreemishra@fedora Sorting-Algorithms-Visualizer]$ python3 main.py
pygame 2.0.3 (SDL 2.0.16, Python 3.9.7)
Hello from the pygame community. https://www.pygame.org/contribute.html
Traceback (most recent call last):
  File "/home/subhashreemishra/Github_projects/Sorting-Algorithms-Visualizer/main.py", line 4, in <module>
    from algs import algorithmsDict
  File "/home/subhashreemishra/Github_projects/Sorting-Algorithms-Visualizer/algs.py", line 1, in <module>
    from algorithms import *
  File "/home/subhashreemishra/Github_projects/Sorting-Algorithms-Visualizer/algorithms/__init__.py", line 1, in <module>
    from algorithms.bubbleSort import bubbleSort
  File "/home/subhashreemishra/Github_projects/Sorting-Algorithms-Visualizer/algorithms/bubbleSort.py", line 10
    if !swapped:
       ^
SyntaxError: invalid syntax
```
It's a small issue that needs fixing.