### PR TITLE
fixed TimSort algorithm bug

### DIFF
--- a/src/algorithms/binaryinsertionSort.py
+++ b/src/algorithms/binaryinsertionSort.py
@@ -17,12 +17,12 @@ def binaryinsertionSort(array, *args):
     """
     for i in range(1, len(array)):
         val = array[i]
-        j = binary_search(array, val, 0, i - 1, i)
+        j = binary_search(array, val, 0, i - 1)
         yield array, 0, i-1, j, i
-        array[0:len(array)] = array[:j] + [val] + array[j:i] + array[i + 1:]
+        array[:] = array[:j] + [val] + array[j:i] + array[i + 1:]
 
 
-def binary_search(arr, val, start, end, current):
+def binary_search(arr, val, start, end):
     """
     Binary search is an efficient search algorithm 
     for finding a target value in a sorted list or array 
@@ -31,7 +31,7 @@ def binary_search(arr, val, start, end, current):
 
     Example:
         >>> arr = [1, 2, 4, 5, 6]
-        >>> binary_search(arr, 3, 0, 4, 4)
+        >>> binary_search(arr, 3, 0, 4)
         2
     """
     if start == end:
@@ -45,8 +45,8 @@ def binary_search(arr, val, start, end, current):
 
     mid = round((start + end) / 2)
     if arr[mid] < val:
-        return binary_search(arr, val, mid + 1, end, current)
+        return binary_search(arr, val, mid + 1, end)
     elif arr[mid] > val:
-        return binary_search(arr, val, start, mid - 1, current)
+        return binary_search(arr, val, start, mid - 1)
     else:
         return mid

--- a/src/algorithms/timSort.py
+++ b/src/algorithms/timSort.py
@@ -1,16 +1,16 @@
 from algorithms.binaryinsertionSort import binary_search
 
+
 def calculate_min_run(n):
     """
-	Calculate the minimum run length for TimSort algorithm.
+    Calculate the minimum run length for TimSort algorithm.
 
     The minimum run length is calculated as follows:
-		1. For any given n, a minimum run length is set to 32.
-		2. A bitwise OR operation is performed on the last bit of the current n and last_bit.
-		3. The current n is right-shifted by 1 bit to prepare for the next iteration.
-		4. Steps 2 and 3 are repeated until n is less than the minimum run length.
-		5. The last bit of the final n is added to the minimum run length to get the actual minimum run length.
-		
+        1. For any given n, a minimum run length is set to 32.
+        2. A bitwise OR operation is performed on the last bit of the current n and last_bit.
+        3. The current n is right-shifted by 1 bit to prepare for the next iteration.
+        4. Steps 2 and 3 are repeated until n is less than the minimum run length.
+        5. The last bit of the final n is added to the minimum run length to get the actual minimum run length.
     """
     last_bit = 0
     RUN_LEN  = 32
@@ -18,80 +18,78 @@ def calculate_min_run(n):
     while n >= RUN_LEN:
         last_bit |= n & 1
         n >>= 1
-        return n + last_bit
 
-def binaryinsertionSort(array, start, end):
+    return n + last_bit
+
+
+def binaryinsertionSort(arr, start, end):
     """
-	Perform binary insertion sort on a portion of the array.
+    Perform binary insertion sort on a portion of the array.
 
     This function takes a slice of the array starting from index start and ending at index end, 
     and performs a binary insertion sort on that slice. It uses the binary_search function from the 
     binaryinsertionSort module to find the insertion point for each element in the slice.
-	"""
+    """
     for i in range(start, end + 1):
-        val = array[i]
-        j   = binary_search(array, val, start, i - 1, i)
-        yield array, start, i-1, j, i
-        array[0: len(array)] = array[: j] + [val] + array[j: i] + array[i + 1:]
+        val = arr[i]
+        j   = binary_search(arr, val, start, i - 1)
+        yield arr, start, i-1, j, i
+        arr[:] = arr[:j] + [val] + arr[j:i] + arr[i + 1:]
+
 
 def merge(arr, left, mid, right):
-	"""
+    """
     This function merges two sorted portions of an array.
     """
 
-	left_arr_size  = mid - left + 1
-	right_arr_size = right - mid
-	left_arr, right_arr = [], []
-	
-	for i in range(left_arr_size) : left_arr.append(arr[left + i])
-	for i in range(right_arr_size): right_arr.append(arr[mid + i + 1])
-	    
-	k, i, j = left, 0, 0
-	while i < left_arr_size and j < right_arr_size:
-		yield arr, left + i, mid + j, left, right
-	    
-		if left_arr[i] <= right_arr[j]:
-			arr[k] = left_arr[i]
-			i += 1
+    left_arr_size  = mid - left + 1
+    right_arr_size = right - mid
+    left_arr = arr[left:mid + 1]
+    right_arr = arr[mid + 1:right + 1]
 
-		else:
-			arr[k] = right_arr[j]
-			j += 1
-			k += 1
+    k, i, j = left, 0, 0
+    while i < left_arr_size and j < right_arr_size:
+        yield arr, left + i, mid + j, left, right
 
-		while i < left_arr_size:
-			arr[k] = left_arr[i]
-			i += 1
-			k += 1
-		while j < right_arr_size:
-			arr[k] = right_arr[j]
-			j += 1
-			k += 1
+        if left_arr[i] <= right_arr[j]:
+            arr[k] = left_arr[i]
+            i += 1
+
+        else:
+            arr[k] = right_arr[j]
+            j += 1
+
+        k += 1
+
+    if i < left_arr_size:
+        arr[k:right + 1] = left_arr[i:]
+    else:
+        arr[k:right + 1] = right_arr[j:]
+
 
 def timSort(arr, beginning, ending):
-	"""
+    """
     Timsort first divides the input list into small 
-	sub-lists called "runs" and sorts each run using Insertion Sort. 
-	It then merges adjacent runs into larger runs until a complete sort is achieved. 
-	The algorithm uses a combination of the best-case time complexity of Insertion Sort 
-	and the worst-case time complexity of Merge Sort to achieve good performance on both 
-	small and large lists.
+    sub-lists called "runs" and sorts each run using Insertion Sort.
+    It then merges adjacent runs into larger runs until a complete sort is achieved.
+    The algorithm uses a combination of the best-case time complexity of Insertion Sort
+    and the worst-case time complexity of Merge Sort to achieve good performance on both
+    small and large lists.
 
-	Time complexity: O(nlog²n).
+    Time complexity: O(nlog²n).
 
     """
-	arr_len = len(arr) 
-	min_run = calculate_min_run(arr_len)
-	
-	for start in range(0, arr_len, min_run): 
-		end = min(start + min_run - 1, arr_len - 1) 
-		yield from binaryinsertionSort(arr, start, end)
-		
-	size = min_run
-	while size < arr_len: 
-		for left in range(0, arr_len, 2 * size): 
-			mid   = min(arr_len - 1, left + size - 1) 
-			right = min(left + 2 * size - 1, arr_len - 1)
-			yield from merge(arr, left, mid, right)
-		size *= 2
-		
+    arr_len = len(arr)
+    min_run = calculate_min_run(arr_len)
+
+    for start in range(0, arr_len, min_run):
+        end = min(start + min_run - 1, arr_len - 1)
+        yield from binaryinsertionSort(arr, start, end)
+
+    size = min_run
+    while size < arr_len:
+        for left in range(0, arr_len, 2 * size):
+            mid   = min(arr_len - 1, left + size - 1)
+            right = min(left + 2 * size - 1, arr_len - 1)
+            yield from merge(arr, left, mid, right)
+        size *= 2

--- a/src/display.py
+++ b/src/display.py
@@ -276,13 +276,13 @@ def drawInterface(array, redBar1, redBar2, blueBar1, blueBar2, **kwargs):
     screen.fill(white)
     drawBars(array, redBar1, redBar2, blueBar1, blueBar2, **kwargs)
     
-    if paused and (time()-timer_space_bar)<0.5:
-        draw_rect_alpha(screen,(255, 255, 0, 127),[(850/2)+10, 150+10, 10, 50])
-        draw_rect_alpha(screen,(255, 255, 0, 127),[(850/2)+40, 150+10, 10, 50])
-        
-    elif not paused and (time()-timer_space_bar)<0.5:
-        x,y = (850/2),150
-        draw_polygon_alpha(screen, (150, 255, 150, 127), ((x+10,y+10),(x+10,y+50+10),(x+50,y+25+10)))
-        
+    if time()-timer_space_bar < 0.5:
+        if paused:
+            draw_rect_alpha(screen, (255, 255, 0, 127), [(850 / 2) + 10, 150 + 10, 10, 50])
+            draw_rect_alpha(screen, (255, 255, 0, 127), [(850 / 2) + 40, 150 + 10, 10, 50])
+        else:
+            x, y = (850 / 2), 150
+            draw_polygon_alpha(screen, (150, 255, 150, 127), ((x + 10, y + 10), (x + 10, y + 50 + 10), (x + 50, y + 25 + 10)))
+
     drawBottomMenu()
     pygame.display.update()

--- a/src/main.py
+++ b/src/main.py
@@ -14,7 +14,6 @@ def main():
     running = True
     display.algorithmBox.add_options(list(algorithmsDict.keys()))
 
-    current_alg = None
     alg_iterator = None
 
     timer_delay = time()
@@ -63,6 +62,7 @@ def main():
         else: # no animation
             a_set = set(range(display.numBars))
             display.drawInterface(numbers, -1, -1, -1, -1, greenRows=a_set)
+
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
There is a problem with the TimSort algorithm as described here: fix #180 

The problem is that in several places there was an unnecessary indentation.

for example:
```
    while n >= RUN_LEN:
        last_bit |= n & 1
        n >>= 1
        return n + last_bit
```

instead of:
```
    while n >= RUN_LEN:
        last_bit |= n & 1
        n >>= 1
    return n + last_bit
```

Things I also did:
- There was a mix between tabs and spaces in the `timSort.py`, so I aligned it all to spaces.
- I improved a little the `timSort.py/merge` function.
- The function `binary_search` was taking an extra argument that is not been used so I removed it.
- Changed `array[0:len(array)]` to `array[:]`.
- Removed the redundant variable `current_alg` from `main.py`.
- Improved a little the structure of an `if` condition in `display.py`.