### PR TITLE
Expose quickSort_LR in algorithm dropdown (refs #210)

### DIFF
--- a/src/algorithms/__init__.py
+++ b/src/algorithms/__init__.py
@@ -16,6 +16,7 @@ from algorithms.stoogeSort import stoogeSort
 from algorithms.shellSort import shellSort
 from algorithms.selectionSort import selectionSort
 from algorithms.quickSort import quickSort
+from algorithms.quickSort_LR import quickSort_LR
 from algorithms.pigeonholeSort import pigeonholeSort
 from algorithms.pancakeSort import pancakeSort
 from algorithms.oddevenSort import oddevenSort
@@ -44,6 +45,7 @@ __all__ = [
     "shellSort",
     "selectionSort",
     "quickSort",
+    "quickSort_LR",
     "pigeonholeSort",
     "pancakeSort",
     "oddevenSort",

--- a/src/algs.py
+++ b/src/algs.py
@@ -7,6 +7,7 @@ algorithmsDict = {
     'selectionSort'       : selectionSort,
     'mergeSort'           : mergeSort,
     'quickSort'           : quickSort,
+    'quickSortLR'         : quickSort_LR,
     'countingSort'        : countingSort,
     'cocktailSort'        : cocktailSort,
     'cycleSort'           : cycleSort,


### PR DESCRIPTION
PR exposes the `quickSort_LR` algorithm in the dropdown.

Files modified:
 - `algorithms/__init__.py`
 - `algs.py`

Tested: `quickSort_LR` can be selected from the dropdown and the animation runs correctly.

<img width="400" height="582" alt="fix-quicksort-LR" src="https://github.com/user-attachments/assets/a7f7463e-adb8-461f-a689-c093b1b7b827" />